### PR TITLE
Update dependency fetch method

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ It should be enough to add the following section
 
 ```
 [dependencies]
-"statebox/idris-ct" = { git = "ssh://git@github.com/statebox/idris-ct" }
+"statebox/idris-ct" = { git = "https://github.com/statebox/idris-ct" }
 ```
 
 to the `elba.toml` file of your project.


### PR DESCRIPTION
Using https to fetch the git repo works right out of the box, no need to set up ssh keys just to add this as a dependency.