### PR TITLE
Update identity definition in TypesAsCategory

### DIFF
--- a/src/Idris/TypesAsCategory.lidr
+++ b/src/Idris/TypesAsCategory.lidr
@@ -30,7 +30,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 > TypeMorphism a b = a -> b
 >
 > identity : (a : Type) -> TypeMorphism a a
-> identity a = id
+> identity a = (\x => x)
 >
 > compose :
 >      (a, b, c : Type)


### PR DESCRIPTION
`identity a = (\x => x)` seems to be definitionally equivalent to `identity a = id`, but in practice the latter makes it difficult to use.

See the attempted definition for the constant Functor_Bool (Idris.Type -> Idris.Type) here: https://gitlab.com/snippets/1933362 that results in the hole `id = (\x => x)` which for some reason unknown to me seems impossible to fill. The proposed changed makes the definition possible.